### PR TITLE
Updated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-selenium==3.14
-#selenium==4.9.1
+# selenium==3.141.0
+selenium==4.9.1
 requests==2.24.0
 colorama==0.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-selenium==3.141.0
+selenium==3.14
+#selenium==4.9.1
 requests==2.24.0
 colorama==0.4.4


### PR DESCRIPTION
If there is no restriction for selenium version, then you can use the latest version which I have updated, this will not give the undetected chromedriver error. If there is a restriction to use specific selenium version then just ignore the undetected chromedriver error because it's a dependency when selenium installs, you can't do anything about it, your selenium still gets installed even after the undetected chromedriver error.